### PR TITLE
[#104182818] endpoints to consume memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 ruby '2.2.2'
 
 gem 'sinatra'
+gem 'vmstat'
+gem 'os'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    os (0.9.6)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -9,9 +10,15 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     tilt (2.0.1)
+    vmstat (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  os
   sinatra
+  vmstat
+
+BUNDLED WITH
+   1.10.3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # cf-example-ruby-sinatra
+
+Test application for cloudfoundry. It implements several useful endpoints
+to test different failure and performance scenarios.
+
+## Endpoints
+
+### /
+
+Return a 'Hello world' home page
+
+### /environment
+
+Prints out system environment variables.
+
+### /sleep/:milliseconds
+
+Sleep for x milliseconds before returning a response
+
+### /mem/alloc/:size_mb/?:leak?/?:once?'
+
+Allocates `size_mb` in MBs in memory before return a response.
+
+Options:
+
+ * `leak == 1`, optional, keep the memory allocated in application
+    scope after returning a response (GC won't delete it)
+ * `once == 1`, optional, allocate only once.
+
+Example: `/mem/alloc/100/1/1`
+
+### /mem/status
+
+Print process memory and system free memory.
+
+### /mem/touch
+
+Forces read all the allocated memory, making the system to page in if required.
+
+### /mem/free
+
+Free the allocated memory.
+
+

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -42,8 +42,6 @@ class SinatraExample < Sinatra::Base
   end
 
   get '/mem/alloc/:size_mb/?:leak?/?:once?' do
-    content_type 'application/text'
-
     if params[:once] and params[:once]=1 and $leak_buffer
       puts "Already has memory allocated, skipping"
       return "Already has memory allocated, skipping"
@@ -84,8 +82,6 @@ Process memory after: #{rss_bytes_after} kiB aka #{rss_bytes_after/1024} MiB
   end
 
   get '/mem/status' do
-    content_type 'application/text'
-
     # Metrics after allocate
     rss_bytes = OS.rss_bytes
     free_mem = (Vmstat.memory.free * Vmstat.memory.pagesize) / 1024

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -76,6 +76,19 @@ Free system memory after: #{free_mem_after} kiB aka #{free_mem_after/1024} MiB
 Process memory before: #{rss_bytes_before} kiB aka #{rss_bytes_before/1024} MiB
 Process memory after: #{rss_bytes_after} kiB aka #{rss_bytes_after/1024} MiB
 """
+  end
+
+  get '/mem/status' do
+    content_type 'application/text'
+
+    # Metrics after allocate
+    rss_bytes = OS.rss_bytes
+    free_mem = (Vmstat.memory.free * Vmstat.memory.pagesize) / 1024
+
+
+    """Process memory: #{rss_bytes} kiB aka #{rss_bytes/1024} MiB
+Process memory: #{rss_bytes} kiB aka #{rss_bytes/1024} MiB
+"""
 
   end
 end

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -2,6 +2,8 @@
 
 require 'sinatra/base'
 require 'tilt/erb'
+require 'vmstat'
+require 'os'
 
 def genload
   1000.times do |i|
@@ -39,4 +41,41 @@ class SinatraExample < Sinatra::Base
     "Finished generating CPU load - #{processes} processes complete"
   end
 
+  get '/mem/:size_mb/?:leak?' do
+    content_type 'application/text'
+
+    size_mb = params[:size_mb].to_i
+    total_bytes = size_mb*1024**2
+    do_leak = (params[:leak] and params[:leak] == "1")
+
+    # Metrics before allowcate
+    rss_bytes_before = OS.rss_bytes
+    free_mem_before = (Vmstat.memory.free * Vmstat.memory.pagesize) / 1024
+
+    puts "Allocating: #{size_mb} MB. Leaking memory: #{if do_leak; "Yes" else  "No" end}, system free: #{free_mem_before/1024} MiB, Process rss: #{rss_bytes_before/1024} MiB"
+
+    # Allocate the memory chunk
+    chunk_of_mem = 'a'*(total_bytes-1)
+    if do_leak
+        $leak_buffer = [] unless $leak_buffer
+        $leak_buffer << chunk_of_mem
+    end
+
+    sleep(1.0/10.0) # To be sure that Vmstat will catch the memory change
+
+    # Metrics after allocate
+    rss_bytes_after = OS.rss_bytes
+    free_mem_after = (Vmstat.memory.free * Vmstat.memory.pagesize) / 1024
+
+    puts "Allocated: #{size_mb} MB. Leaking memory: #{if do_leak; "Yes" else  "No" end}, system free: #{free_mem_after/1024} MiB, Process rss: #{rss_bytes_after/1024} MiB"
+
+    """Allocated #{size_mb} MB = #{total_bytes} bytes.
+Leaking memory: #{if do_leak; "Yes" else  "No" end}
+Free system memory before: #{free_mem_before} kiB aka #{free_mem_before/1024} MiB
+Free system memory after: #{free_mem_after} kiB aka #{free_mem_after/1024} MiB
+Process memory before: #{rss_bytes_before} kiB aka #{rss_bytes_before/1024} MiB
+Process memory after: #{rss_bytes_after} kiB aka #{rss_bytes_after/1024} MiB
+"""
+
+  end
 end

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -102,6 +102,11 @@ Process memory: #{rss_bytes} kiB aka #{rss_bytes/1024} MiB
       m.index("A very long string to forces load all the string in memory to search for it :)")
     }
     puts "Done reading all memory blocks"
+  end
 
+  # Mark all the memory blocks allocated by /mem/alloc as ready to be freed by the GC
+  get '/mem/free' do
+    $leak_buffer = nil
+    GC.start
   end
 end

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -41,8 +41,13 @@ class SinatraExample < Sinatra::Base
     "Finished generating CPU load - #{processes} processes complete"
   end
 
-  get '/mem/alloc/:size_mb/?:leak?' do
+  get '/mem/alloc/:size_mb/?:leak?/?:once?' do
     content_type 'application/text'
+
+    if params[:once] and params[:once]=1 and $leak_buffer
+      puts "Already has memory allocated, skipping"
+      return "Already has memory allocated, skipping"
+    end
 
     size_mb = params[:size_mb].to_i
     total_bytes = size_mb*1024**2

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -41,7 +41,7 @@ class SinatraExample < Sinatra::Base
     "Finished generating CPU load - #{processes} processes complete"
   end
 
-  get '/mem/:size_mb/?:leak?' do
+  get '/mem/alloc/:size_mb/?:leak?' do
     content_type 'application/text'
 
     size_mb = params[:size_mb].to_i

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -89,6 +89,19 @@ Process memory after: #{rss_bytes_after} kiB aka #{rss_bytes_after/1024} MiB
     """Process memory: #{rss_bytes} kiB aka #{rss_bytes/1024} MiB
 Process memory: #{rss_bytes} kiB aka #{rss_bytes/1024} MiB
 """
+  end
+
+  # Read all the memory allocated by /mem/alloc endpoint, so the system
+  # will be forced to page it in from swap if needed.
+  get '/mem/touch' do
+    return unless $leak_buffer
+
+    $leak_buffer.each_with_index { |m, index|
+      puts "Reading memory blocks #{index+1} of #{$leak_buffer.length} to page it in."
+
+      m.index("A very long string to forces load all the string in memory to search for it :)")
+    }
+    puts "Done reading all memory blocks"
 
   end
 end

--- a/views/home.erb
+++ b/views/home.erb
@@ -14,6 +14,10 @@
         <li><a href="/environment" title="Environment Variables">Environment Variables</a></li>
         <li><a href="/sleep/1000" title="Sleep for X Milliseconds">Sleep for X Milliseconds</a></li>
         <li><a href="/cpuload/4" title="Generate X Number of Processes to produce CPU Load">Generate X Number of Processes to produce CPU Load</a></li>
+        <li><a href="/mem/alloc/10/1" title="Allocate memory">Allocate memory</a></li>
+        <li><a href="/mem/status" title="Memory stats">Memory stats</a></li>
+        <li><a href="/mem/touch" title="Read allocated memory">Read allocated memory</a></li>
+        <li><a href="/mem/free" title="Free allocated memory">Free allocated memory</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
[#104182818 Test an app that consumes a large amount of memory](https://www.pivotaltracker.com/n/projects/1275640/stories/104182818)
# What

We want to test an app that consumes a lot of memory.

This PR adds endpoints to simulate that scenario
# How to review this

Test the different endpoints to see how the app consumes more memory:
- `curl https://cf-example-ruby-sinatra-nonheinous-overpowerfulness.skookum.cf.paas.alphagov.co.uk/mem/alloc/100/1/1` => Allocate 1G
- `curl https://cf-example-ruby-sinatra-nonheinous-overpowerfulness.skookum.cf.paas.alphagov.co.uk/mem/free` => Free memory

The app was used to carry on the tests described in [#104182818 Test an app that consumes a large amount of memory](https://www.pivotaltracker.com/n/projects/1275640/stories/104182818)
# who can review this

Anyone but @jimconner or @keymon
