### PR TITLE
[#104520100] Add /simplecpuload endpoint

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,4 @@
 applications:
 - name: cf-example-ruby-sinatra
   memory: 512M
-  instances: 1
-  host: cf-example-ruby-sinatra-${random-word}
-
+  host: cf-example-ruby-sinatra

--- a/sinatra-example.rb
+++ b/sinatra-example.rb
@@ -5,9 +5,9 @@ require 'tilt/erb'
 require 'vmstat'
 require 'os'
 
-def genload
-  1000.times do |i|
-    100000.downto(1) do |j|
+def genload(repetitions)
+  repetitions.times do |i|
+    10000.downto(1) do |j|
       Math.sqrt(j) * i / 0.2
     end
   end
@@ -40,11 +40,18 @@ class SinatraExample < Sinatra::Base
     "slept for #{milliseconds} milliseconds"
   end
 
+  get '/simplecpuload/?:repetitions?' do
+    repetitions = (params[:repetitions] || 10).to_i
+    genload repetitions
+
+    "Done computing. The answer is: 42"
+  end
+
   get '/cpuload/:processes' do
     processes = params[:processes].to_i
     processes.times do |p|
       child_pid = Process.fork do
-        genload
+        genload 1000
       end
     end
 

--- a/views/home.erb
+++ b/views/home.erb
@@ -13,6 +13,7 @@
         <li><a href="/" title="Home">Home</a></li>
         <li><a href="/environment" title="Environment Variables">Environment Variables</a></li>
         <li><a href="/sleep/1000" title="Sleep for X Milliseconds">Sleep for X Milliseconds</a></li>
+        <li><a href="/simplecpuload/100" title="Produces X CPU load">Produces X CPU Load</a></li>
         <li><a href="/cpuload/4" title="Generate X Number of Processes to produce CPU Load">Generate X Number of Processes to produce CPU Load</a></li>
         <li><a href="/mem/alloc/10/1" title="Allocate memory">Allocate memory</a></li>
         <li><a href="/mem/status" title="Memory stats">Memory stats</a></li>


### PR DESCRIPTION
# What

Add /simplecpuload endpoint to generate CPU load at each request.

Specify a number in `/simplecpuload/<number>` to load the system more and more.
# How

```
$ bundle install
$ bundle exec rackup
[2015-10-20 15:42:32] INFO  WEBrick 1.3.1
[2015-10-20 15:42:32] INFO  ruby 2.2.2 (2015-04-13) [x86_64-darwin14]
[2015-10-20 15:42:32] INFO  WEBrick::HTTPServer#start: pid=18655 port=9292
$ curl localhost:9292/simplecpuload
Done computing. The answer is: 42
$ curl localhost:9292/simplecpuload/100
Done computing. The answer is: 42
```
# Who

Anyone but @saliceti or @jimconner 
